### PR TITLE
Send a winit WakeUp event whenever file picking (or similar) completes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ bevy_tasks = { version = "0.15.0-rc.3", features = ["multi_threaded"] }
 bevy_app = { version = "0.15.0-rc.3", default-features = false }
 bevy_ecs = { version = "0.15.0-rc.3", default-features = false }
 bevy_utils = "0.15.0-rc.3"
+bevy_winit = { version = "0.15.0-rc.3", default-features = false }
 bevy_derive = "0.15.0-rc.3"
 
 [dev-dependencies]

--- a/examples/desktop_app.rs
+++ b/examples/desktop_app.rs
@@ -1,0 +1,37 @@
+//! This example demonstrates picking of a file path when using
+//! [`WinitSettings::desktop_app`] or similar settings.
+
+use std::time::Duration;
+
+use bevy::{
+    prelude::*,
+    winit::{UpdateMode, WinitSettings},
+};
+use bevy_file_dialog::{DialogFilePicked, FileDialogExt, FileDialogPlugin};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .insert_resource(WinitSettings {
+            focused_mode: UpdateMode::reactive(Duration::from_secs(3600)),
+            unfocused_mode: UpdateMode::reactive_low_power(Duration::from_secs(3600)),
+        })
+        // Add the file dialog plugin and specify that we want to pick
+        // directories with `PrintFilePath` marker
+        .add_plugins(FileDialogPlugin::new().with_pick_file::<PrintFilePath>())
+        .add_systems(Startup, pick)
+        .add_systems(Update, file_picked)
+        .run();
+}
+
+struct PrintFilePath;
+
+fn pick(mut commands: Commands) {
+    commands.dialog().pick_file_path::<PrintFilePath>();
+}
+
+fn file_picked(mut ev_picked: EventReader<DialogFilePicked<PrintFilePath>>) {
+    for ev in ev_picked.read() {
+        eprintln!("File picked, path {:?}", ev.path);
+    }
+}

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -4,11 +4,13 @@ use std::path::PathBuf;
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_tasks::prelude::*;
+use bevy_winit::{EventLoopProxy, EventLoopProxyWrapper, WakeUp};
 use crossbeam_channel::bounded;
 use rfd::AsyncFileDialog;
 
 use crate::{
     handle_dialog_result, DialogResult, FileDialog, FileDialogPlugin, StreamReceiver, StreamSender,
+    WakeUpOnDrop,
 };
 
 /// Event that gets sent when directory path gets selected from file system.
@@ -121,9 +123,14 @@ impl<'w, 's, 'a> FileDialog<'w, 's, 'a> {
                 .0
                 .clone();
 
+            let event_loop_proxy = world
+                .get_resource::<EventLoopProxyWrapper<WakeUp>>()
+                .map(|proxy| EventLoopProxy::clone(&**proxy));
+
             AsyncComputeTaskPool::get()
                 .spawn(async move {
                     let file = self.dialog.pick_folder().await;
+                    let _wake_up = event_loop_proxy.as_ref().map(|proxy| WakeUpOnDrop(proxy));
 
                     let Some(file) = file else {
                         sender.send(DialogResult::Canceled).unwrap();
@@ -155,9 +162,14 @@ impl<'w, 's, 'a> FileDialog<'w, 's, 'a> {
                 .0
                 .clone();
 
+            let event_loop_proxy = world
+                .get_resource::<EventLoopProxyWrapper<WakeUp>>()
+                .map(|proxy| EventLoopProxy::clone(&**proxy));
+
             AsyncComputeTaskPool::get()
                 .spawn(async move {
                     let files = AsyncFileDialog::new().pick_folders().await;
+                    let _wake_up = event_loop_proxy.as_ref().map(|proxy| WakeUpOnDrop(proxy));
 
                     let Some(files) = files else {
                         sender.send(DialogResult::Canceled).unwrap();
@@ -193,9 +205,14 @@ impl<'w, 's, 'a> FileDialog<'w, 's, 'a> {
                 .0
                 .clone();
 
+            let event_loop_proxy = world
+                .get_resource::<EventLoopProxyWrapper<WakeUp>>()
+                .map(|proxy| EventLoopProxy::clone(&**proxy));
+
             AsyncComputeTaskPool::get()
                 .spawn(async move {
                     let file = self.dialog.pick_file().await;
+                    let _wake_up = event_loop_proxy.as_ref().map(|proxy| WakeUpOnDrop(proxy));
 
                     let Some(file) = file else {
                         sender.send(DialogResult::Canceled).unwrap();
@@ -229,9 +246,14 @@ impl<'w, 's, 'a> FileDialog<'w, 's, 'a> {
                 .0
                 .clone();
 
+            let event_loop_proxy = world
+                .get_resource::<EventLoopProxyWrapper<WakeUp>>()
+                .map(|proxy| EventLoopProxy::clone(&**proxy));
+
             AsyncComputeTaskPool::get()
                 .spawn(async move {
                     let files = AsyncFileDialog::new().pick_files().await;
+                    let _wake_up = event_loop_proxy.as_ref().map(|proxy| WakeUpOnDrop(proxy));
 
                     let Some(files) = files else {
                         sender.send(DialogResult::Canceled).unwrap();


### PR DESCRIPTION
Fixes #7.

Previously, using `WinitSettings::desktop_app()` or similar would result in a delay after file picking before the app reacts (since the channel would get the `DialogResult`, but Bevy wouldn't react until a winit event or the reaction delay hits - by default, 5 seconds). Now we send a winit event to wake up the event loop resulting in instant feedback.

I've tested this with the corresponding example and it behaves correctly now!